### PR TITLE
fix: include departed players in match results and prevent ghost room…

### DIFF
--- a/services/game-service/src/app/room_manager.ts
+++ b/services/game-service/src/app/room_manager.ts
@@ -42,6 +42,7 @@ type Room = {
 	// Players
 	hostId: string;
 	players: Player[];
+	allPlayers: Player[];					// snapshot of all participants at game start (never mutated by dropPlayer)
 	sceneById: Record<string, PlayerPhase>;
 	inputsById: Record<string, TurnInput>;
 	finishOrder: string[];					// [firstOut, ..., winner]
@@ -166,6 +167,7 @@ export class RoomManager {
 			state,
 			hostId,
 			players: [...players],
+			allPlayers: [],
 			sceneById,
 			inputsById,
 			finishOrder: [],
@@ -213,6 +215,10 @@ export class RoomManager {
 	private addPlayerToRoom(roomId: string, player: Player) {
 		const room = this.getRoomOrThrow(roomId);
 		if (room.phase === "finished") throw new Error(`Room ${roomId} is finished`);
+		if (room.phase === "running" || room.phase === "ready") {
+			const alreadyIn = room.players.some(p => p.playerId === player.playerId);
+			if (!alreadyIn) throw new Error(`Room ${roomId} is already in progress`);
+		}
 
 		const existing = this.getPlayer(room, player.playerId);
 		const wasAlreadyInRoom = !!existing;
@@ -816,6 +822,7 @@ export class RoomManager {
 		}
 
 		room.phase = "running";
+		room.allPlayers = room.players.map(p => ({ ...p }));
 
 		logInfo("room.phase_changed", { roomId, from: "ready", to: "running" });
 
@@ -1003,17 +1010,17 @@ export class RoomManager {
 	}
 
 	private computeAndApplyNewRatings(room: Room) {
-		const playerIds = new Set(room.players.map(p => p.playerId));
-  		const finishOrder = room.finishOrder.filter(id => playerIds.has(id));
-		
-		const playerRatings = room.players.map((p) => ({
+		// Use allPlayers (snapshot from game start) so departed players are included
+		const allP = room.allPlayers.length > 0 ? room.allPlayers : room.players;
+
+		const playerRatings = allP.map((p) => ({
 			id: p.playerId,
 			mu: p.rating_mu,
 			sigma: p.rating_sigma,
 		}));
 
 		logInfo("ratings.pre", {
-			players: room.players.map((p) => ({
+			players: allP.map((p) => ({
 				id: p.playerId,
 				mu: p.rating_mu,
 				sigma: p.rating_sigma,
@@ -1021,12 +1028,12 @@ export class RoomManager {
 		});
 
 		// Compute new ratings with OpenSkill
-		const updated = updateRatingsOpenSkill(playerRatings, { finishOrder });
+		const updated = updateRatingsOpenSkill(playerRatings, { finishOrder: room.finishOrder });
 		
-		// Merge updated mu/sigma back into room.players
+		// Merge updated mu/sigma back into allPlayers
 		const updatedById = new Map(updated.map((u) => [u.id, u] as const));
 
-		room.players = room.players.map((p) => {
+		room.allPlayers = allP.map((p) => {
 			const u = updatedById.get(p.playerId);
 			if (!u) return p;
 
@@ -1038,7 +1045,7 @@ export class RoomManager {
 		});
 
 		logInfo("ratings.post", {
-			players: room.players.map((p) => ({
+			players: room.allPlayers.map((p) => ({
 				id: p.playerId,
 				mu: p.rating_mu,
 				sigma: p.rating_sigma,
@@ -1076,9 +1083,10 @@ export class RoomManager {
 		try {
 			this.computeAndApplyNewRatings(room);
 
-			// Build backend payload
+			// Build backend payload from allPlayers (includes departed players)
+			const allP = room.allPlayers.length > 0 ? room.allPlayers : room.players;
 			const payload = this.toFinishPayload(
-				room.players.map((p) => ({
+				allP.map((p) => ({
 					playerId: p.playerId,
 					rating_mu: p.rating_mu,
 					rating_sigma: p.rating_sigma,

--- a/services/game-service/src/transport/external_ws.ts
+++ b/services/game-service/src/transport/external_ws.ts
@@ -139,18 +139,19 @@ export function startPublicWsServer(
 							boundPlayerId = null;
 						}
 
-						boundRoomId = msg.roomId;
-						boundPlayerId = msg.player.playerId;
-
 						const config = normalizeConfig(msg.config);
 						const seed = msg.seed;
 
+						// Join 'before' setting bindings - if it throws, bindings stay clean
 						rooms.createOrJoinRoom({
-							roomId: boundRoomId,
+							roomId: msg.roomId,
 							player: msg.player,
 							seed,
 							config,
 						});
+
+						boundRoomId = msg.roomId;
+						boundPlayerId = msg.player.playerId;
 
 						rooms.subscribe(boundRoomId, ws);
 						safeSendServer(ws, { type: "joined", roomId: boundRoomId, playerId: boundPlayerId } satisfies ServerMsg);


### PR DESCRIPTION
… on rejoin #158

Players who navigated away mid-game were dropped from room.players before finishRoom ran, so they were excluded from ratings and match history. This also let them accidentally rejoin a finished/running room, creating a ghost game state.

- Snapshot all participants (allPlayers) when game starts running
- Use allPlayers for rating calculation and backend finish payload
- Block new players from joining rooms in running/ready phase
- Set WS bindings only after successful join to prevent stale state